### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/pkg/sp/sp.go
+++ b/pkg/sp/sp.go
@@ -171,8 +171,29 @@ func (sp *ServiceProvider) initmw() error {
 	return nil
 }
 
+func (s *ServiceProvider) redactedHeaders(h http.Header) http.Header {
+	redacted := h.Clone()
+	sensitive := map[string]struct{}{
+		"Authorization":       {},
+		"Proxy-Authorization": {},
+		"Cookie":              {},
+		"Set-Cookie":          {},
+		"X-Api-Key":           {},
+		"X-Auth-Token":        {},
+		"X-Amz-Security-Token": {},
+	}
+
+	for key := range redacted {
+		if _, ok := sensitive[http.CanonicalHeaderKey(key)]; ok {
+			redacted[key] = []string{"[REDACTED]"}
+		}
+	}
+
+	return redacted
+}
+
 func (s *ServiceProvider) ForwardAuthHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("got request", "headers", r.Header)
+	slog.Debug("got request", "headers", s.redactedHeaders(r.Header))
 
 	// check provided headers
 	if err := s.checkHeaders(r); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/andrewheberle/go-http-auth-server/security/code-scanning/4](https://github.com/andrewheberle/go-http-auth-server/security/code-scanning/4)

To fix this without changing behavior, stop logging raw `r.Header` and log a sanitized/redacted copy instead.

Best implementation in this file/region:
- In `pkg/sp/sp.go`, inside `ForwardAuthHandler`, replace the current debug statement on line 175 with one that logs a redacted header map.
- Add a helper method on `ServiceProvider` (in the same file) that clones request headers and masks values for sensitive header names (for example: `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, common token/key headers).
- Keep non-sensitive headers visible for debugging.
- This preserves logging and troubleshooting value while preventing clear-text leakage of secrets.

No external dependency is required; use standard library types already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
